### PR TITLE
feat: limit scope required when create account, check scope current t…

### DIFF
--- a/src/controllers/account/delete.action.ts
+++ b/src/controllers/account/delete.action.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { AccountService } from '../../services/AccountService';
 
 export const deleteAccount = async (req: Request, res: Response) => {
-    await AccountService.remove(req.user.sub);
+    await AccountService.remove((req.user as any).sub);
 
     res.status(204).end();
 };

--- a/src/controllers/account/youtube/get.action.ts
+++ b/src/controllers/account/youtube/get.action.ts
@@ -9,11 +9,13 @@ export const getYoutube = async (req: Request, res: Response) => {
         return res.json({ isAuthorized: false });
     }
 
-    const channels = await YouTubeService.getChannelList(account);
-    const videos = await YouTubeService.getVideoList(account);
+    const haveExpanedScopes = await YouTubeService.haveExpandedScopes(account.googleAccessToken);
+
+    const channels = haveExpanedScopes ? await YouTubeService.getChannelList(account) : [];
+    const videos = haveExpanedScopes ? await YouTubeService.getVideoList(account) : [];
 
     res.json({
-        isAuthorized: true,
+        isAuthorized: haveExpanedScopes,
         channels,
         videos,
     });

--- a/src/controllers/oidc/claim/get.ts
+++ b/src/controllers/oidc/claim/get.ts
@@ -11,7 +11,7 @@ async function controller(req: Request, res: Response) {
     const skinData = await SkinService.get(poolAddress);
 
     params.rewardData = rewardData;
-    params.googleLoginUrl = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getReadOnlyScope());
+    params.googleLoginUrl = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getExpandedScopes());
     params.backgroundImgUrl = skinData?.backgroundImgUrl;
     params.logoImgUrl = skinData?.logoImgUrl;
 

--- a/src/controllers/oidc/connect/get.ts
+++ b/src/controllers/oidc/connect/get.ts
@@ -12,8 +12,15 @@ async function controller(req: Request, res: Response) {
     const account = await AccountService.get(session.accountId);
     let redirect = '';
 
-    if (params.channel == ChannelType.Google && !account.googleAccessToken) {
-        redirect = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getReadOnlyScope());
+    if (params.channel == ChannelType.Google) {
+        if (account.googleAccessToken) {
+            const haveExpandedScopes = await YouTubeService.haveExpandedScopes(account.googleAccessToken);
+            if (!haveExpandedScopes) {
+                redirect = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getExpandedScopes());
+            }
+        } else {
+            redirect = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getExpandedScopes());
+        }
     } else if (params.channel == ChannelType.Twitter && !account.twitterAccessToken) {
         redirect = TwitterService.getLoginURL(uid);
     } else if (params.channel == ChannelType.Spotify && !account.spotifyAccessToken) {

--- a/src/controllers/oidc/signin/get.ts
+++ b/src/controllers/oidc/signin/get.ts
@@ -7,7 +7,7 @@ import { YouTubeService } from '../../../services/YouTubeService';
 async function controller(req: Request, res: Response) {
     const { uid, params } = req.interaction;
 
-    params.googleLoginUrl = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getReadOnlyScope());
+    params.googleLoginUrl = YouTubeService.getLoginUrl(req.params.uid, YouTubeService.getBasicScopes());
 
     if (params.return_url === WALLET_URL) {
         params.twitterLoginUrl = TwitterService.getLoginURL(uid);

--- a/src/services/YouTubeService.ts
+++ b/src/services/YouTubeService.ts
@@ -143,6 +143,22 @@ export class YouTubeService {
         });
     }
 
+    static async getScopesOfAccessToken(token: string): Promise<string[]> {
+        const response = await axios({
+            url: `https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=${token}`,
+        });
+        return response.data['scope'].split(' ');
+    }
+
+    static async haveExpandedScopes(token: string): Promise<boolean> {
+        const expanedScopes = this.getExpandedScopes();
+        const scopes = await YouTubeService.getScopesOfAccessToken(token);
+
+        const missingScope = scopes.length !== expanedScopes.length;
+
+        return !missingScope;
+    }
+
     static async revokeAccess(account: AccountDocument) {
         const r = await axios({
             url: `https://oauth2.googleapis.com/revoke?token=${account.googleAccessToken}`,
@@ -167,11 +183,11 @@ export class YouTubeService {
         return res.tokens;
     }
 
-    static getScope() {
-        return ['https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/youtube'];
+    static getBasicScopes() {
+        return ['https://www.googleapis.com/auth/userinfo.email', 'openid'];
     }
 
-    static getReadOnlyScope() {
-        return ['https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/youtube.readonly'];
+    static getExpandedScopes() {
+        return ['https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/youtube', 'openid'];
     }
 }

--- a/src/util/social.ts
+++ b/src/util/social.ts
@@ -6,9 +6,8 @@ import { SPOTIFY_API_SCOPE, SpotifyService } from '../services/SpotifyService';
 function getChannelScopes(channelAction: ChannelAction) {
     switch (channelAction) {
         case ChannelAction.YouTubeLike:
-            return { channelScopes: YouTubeService.getScope() };
         case ChannelAction.YouTubeSubscribe:
-            return { channelScopes: YouTubeService.getReadOnlyScope() };
+            return { channelScopes: YouTubeService.getExpandedScopes() };
         case ChannelAction.TwitterLike:
         case ChannelAction.TwitterRetweet:
         case ChannelAction.TwitterFollow:
@@ -25,9 +24,8 @@ function getChannelScopes(channelAction: ChannelAction) {
 function getLoginLinkForChannelAction(uid: string, channelAction: ChannelAction) {
     switch (channelAction) {
         case ChannelAction.YouTubeLike:
-            return { googleLoginUrl: YouTubeService.getLoginUrl(uid, YouTubeService.getScope()) };
         case ChannelAction.YouTubeSubscribe:
-            return { googleLoginUrl: YouTubeService.getLoginUrl(uid, YouTubeService.getReadOnlyScope()) };
+            return { googleLoginUrl: YouTubeService.getLoginUrl(uid, YouTubeService.getExpandedScopes()) };
         case ChannelAction.TwitterLike:
         case ChannelAction.TwitterRetweet:
         case ChannelAction.TwitterFollow:


### PR DESCRIPTION
- Only require google email while login
- Check scope on /oicd/connect route and /account/youtube to return correct state of scope of current user

