### PR TITLE
Fix generated jwks.json path

### DIFF
--- a/src/util/jwks.ts
+++ b/src/util/jwks.ts
@@ -9,7 +9,7 @@ export function getJwks() {
         return JSON.parse(JWKS_JSON);
     }
 
-    const jwksPath = path.resolve('../jwks.json');
+    const jwksPath = path.resolve(path.dirname(__dirname), 'jwks.json');
 
     if (!fs.existsSync(jwksPath)) {
         logger.warn('No JWKS_JSON env var set and no jwks.json present, generating a new one.');


### PR DESCRIPTION
Instead of 1 dir up from the `jwks.ts` file the jwks.json was placed one dir up of `cwd`. Not anymore! You'll find it in the src/ dir where it's excluded from git.