### PR TITLE
Stop passing ca as a parameter to https.createServer

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,13 @@ cp .env.example .env
 # 3. This readme assumes you have installed the API. 
 # Copy it's `./certs` folder to the root of this project
 
+or use [mkcert](https://github.com/FiloSottile/mkcert) and run
+
+```
+mdir certs
+mkcert -key-file certs/localhost.key -cert-file certs/localhost.crt localhost
+```
+
 # 4. Create jwks
 npm run build:keys
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,6 @@ if (app.get('env') === 'development') {
         {
             key: fs.readFileSync(dir + '/certs/localhost.key'),
             cert: fs.readFileSync(dir + '/certs/localhost.crt'),
-            ca: fs.readFileSync(dir + '/certs/rootCA.crt'),
         },
         app,
     );


### PR DESCRIPTION
This allows using mkcert since it doesn't easily supply you with the root CA.