### PR TITLE
feature: add timeout for token refresh

### DIFF
--- a/src/controllers/account/spotify/get.action.ts
+++ b/src/controllers/account/spotify/get.action.ts
@@ -6,7 +6,7 @@ import { AccountService } from '../../../services/AccountService';
 export const getSpotify = async (req: Request, res: Response) => {
     async function updateTokens(account: AccountDocument, newAccessToken: string) {
         account.spotifyAccessToken = newAccessToken || account.spotifyAccessToken;
-        account.spotifyAccessTokenExpires = Date.now() + Number(3600) * 1000;
+        account.spotifyAccessTokenExpires = Date.now() + Number(3600) * 1000 - 4000;
 
         return await account.save();
     }

--- a/src/controllers/account/twitter/get.action.ts
+++ b/src/controllers/account/twitter/get.action.ts
@@ -8,7 +8,7 @@ export const getTwitter = async (req: Request, res: Response) => {
         account.twitterAccessToken = tokens.access_token || account.twitterAccessToken;
         account.twitterRefreshToken = tokens.refresh_token || account.twitterRefreshToken;
         account.twitterAccessTokenExpires = tokens.expires_in
-            ? Date.now() + Number(tokens.expires_in) * 1000
+            ? Date.now() + Number(tokens.expires_in) * 1000 - 4000
             : account.twitterAccessTokenExpires;
 
         return await account.save();


### PR DESCRIPTION
**What**
- Checked and doesn't seem anything wrong with the token refresh function, but there will be a change, that due to slow connection (or high network usage in mainnet so the token (which is fine when send back by service) expired, to prevent that, I added a buffer (4 secs) to prevent there cases.



